### PR TITLE
Change submodule URL to use HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third-party/prbench"]
 	path = third-party/prbench
-	url = git@github.com:Princeton-Robot-Planning-and-Learning/prbench.git
+	url = https://github.com/Princeton-Robot-Planning-and-Learning/prbench.git


### PR DESCRIPTION
My CI was failing during dependency install because a submodule was using SSH (git@...) and the runner doesn’t have SSH keys. The error I saw was:
```
Cloning into
      '/home/runner/work/_temp/setup-uv-cache/git-v0/checkouts/2ae32e6a8db4cd99/59345be/third-party/prbench'...
      git@github.com: Permission denied (publickey).
      fatal: Could not read from remote repository.

      Please make sure you have the correct access rights
      and the repository exists.
      fatal: clone of
      'git@github.com:Princeton-Robot-Planning-and-Learning/prbench.git'
      into submodule path
      '/home/runner/work/_temp/setup-uv-cache/git-v0/checkouts/2ae32e6a8db4cd99/59345be/third-party/prbench'
      failed
```
I switched the submodule URL(s) to HTTPS so public clones can work out of the box on GitHub Actions.